### PR TITLE
fixed parsing when using non-standard LiDAR type

### DIFF
--- a/src/frsm-lcm/frsm-lcm.cpp
+++ b/src/frsm-lcm/frsm-lcm.cpp
@@ -263,7 +263,7 @@ int main(int argc, char *argv[])
   app->maxRange = 29.7;
   app->laser_queue = new deque<frsm_planar_lidar_t *>();
 
-  bool isUtm = true;
+  bool isUtm = false;
   bool isUrg = false, isSick = false;
 
   ConciseArgs opt(argc, argv);
@@ -288,7 +288,9 @@ int main(int argc, char *argv[])
   opt.parse();
 
   int numModes = (int) isUtm + (int) isUrg + (int) isSick;
-  if (numModes > 1) {
+  if(numModes == 0){
+	  isUtm = true;
+  } else if (numModes > 1) {
     fprintf(stderr, "Only one lidar type may be specified at once\n");
     opt.usage(true);
   }


### PR DESCRIPTION
When choosing a lidar different from UTM, in command line you had to chose the UTM first (to flip the flag) and the one you want. With this modification you just choose the one you want.
