### PR TITLE
Added min range for LiDAR scan matcher

### DIFF
--- a/src/frsm-lcm/frsm-lcm.cpp
+++ b/src/frsm-lcm/frsm-lcm.cpp
@@ -91,7 +91,7 @@ static void process_laser(const frsm_planar_lidar_t * msg, void * user __attribu
   ////////////////////////////////////////////////////////////////////
   frsmPoint * points = (frsmPoint *) calloc(msg->nranges, sizeof(frsmPoint));
   int numValidPoints = frsm_projectRangesAndDecimate(app->beam_skip, app->spatialDecimationThresh, msg->ranges,
-	  msg->nranges, msg->rad0, msg->radstep, points, app->maxRange, app->minRange, app->validBeamAngles[0], app->validBeamAngles[1]);
+      msg->nranges, msg->rad0, msg->radstep, points, app->minRange, app->maxRange, app->validBeamAngles[0], app->validBeamAngles[1]);
   if (numValidPoints < 30) {
     fprintf(stderr, "WARNING! NOT ENOUGH VALID POINTS! numValid=%d\n", numValidPoints);
     return;

--- a/src/libfrsm/ScanMatchingUtils.hpp
+++ b/src/libfrsm/ScanMatchingUtils.hpp
@@ -327,7 +327,7 @@ inline void frsm_transformPoints(ScanTransform *T, frsmPoint * points, unsigned 
 }
 
 inline int frsm_projectRangesToPoints(float * ranges, int numPoints, double thetaStart, double thetaStep,
-	frsmPoint * points, double maxRange = 1e10, double minRange = .1, double validRangeStart = -1000, double validRangeEnd = 1000,
+    frsmPoint * points, double minRange = .1, double maxRange = 1e10, double validRangeStart = -1000, double validRangeEnd = 1000,
     double * aveValidRange = NULL, double * stddevValidRange = NULL)
 {
   int count = 0;
@@ -360,13 +360,13 @@ inline int frsm_projectRangesToPoints(float * ranges, int numPoints, double thet
 }
 
 inline int frsm_projectRangesAndDecimate(int beamskip, float spatialDecimationThresh, float * ranges, int numPoints,
-	double thetaStart, double thetaStep, frsmPoint * points, double maxRange = 1e10, double minRange = .1, double validRangeStart = -1000,
+    double thetaStart, double thetaStep, frsmPoint * points, double minRange = .1, double maxRange = 1e10, double validRangeStart = -1000,
     double validRangeEnd = 1000)
 {
   int lastAdd = -1000;
   double aveRange;
   double stdDevRange;
-  int numValidPoints = frsm_projectRangesToPoints(ranges, numPoints, thetaStart, thetaStep, points, maxRange, minRange,
+  int numValidPoints = frsm_projectRangesToPoints(ranges, numPoints, thetaStart, thetaStep, points, minRange, maxRange,
       validRangeStart, validRangeEnd, &aveRange, &stdDevRange);
 
   frsmPoint origin = { 0, 0 };

--- a/src/libfrsm/ScanMatchingUtils.hpp
+++ b/src/libfrsm/ScanMatchingUtils.hpp
@@ -327,7 +327,7 @@ inline void frsm_transformPoints(ScanTransform *T, frsmPoint * points, unsigned 
 }
 
 inline int frsm_projectRangesToPoints(float * ranges, int numPoints, double thetaStart, double thetaStep,
-    frsmPoint * points, double maxRange = 1e10, double validRangeStart = -1000, double validRangeEnd = 1000,
+	frsmPoint * points, double maxRange = 1e10, double minRange = .1, double validRangeStart = -1000, double validRangeEnd = 1000,
     double * aveValidRange = NULL, double * stddevValidRange = NULL)
 {
   int count = 0;
@@ -336,7 +336,7 @@ inline int frsm_projectRangesToPoints(float * ranges, int numPoints, double thet
 
   double theta = thetaStart;
   for (int i = 0; i < numPoints; i++) {
-    if (ranges[i] > .1 && ranges[i] < maxRange && theta > validRangeStart && theta < validRangeEnd) { //hokuyo driver seems to report maxRanges as .001 :-/
+	if (ranges[i] > minRange && ranges[i] < maxRange && theta > validRangeStart && theta < validRangeEnd) { //hokuyo driver seems to report maxRanges as .001 :-/
       //project to body centered coordinates
       points[count].x = ranges[i] * cos(theta);
       points[count].y = ranges[i] * sin(theta);
@@ -360,13 +360,13 @@ inline int frsm_projectRangesToPoints(float * ranges, int numPoints, double thet
 }
 
 inline int frsm_projectRangesAndDecimate(int beamskip, float spatialDecimationThresh, float * ranges, int numPoints,
-    double thetaStart, double thetaStep, frsmPoint * points, double maxRange = 1e10, double validRangeStart = -1000,
+	double thetaStart, double thetaStep, frsmPoint * points, double maxRange = 1e10, double minRange = .1, double validRangeStart = -1000,
     double validRangeEnd = 1000)
 {
   int lastAdd = -1000;
   double aveRange;
   double stdDevRange;
-  int numValidPoints = frsm_projectRangesToPoints(ranges, numPoints, thetaStart, thetaStep, points, maxRange,
+  int numValidPoints = frsm_projectRangesToPoints(ranges, numPoints, thetaStart, thetaStep, points, maxRange, minRange,
       validRangeStart, validRangeEnd, &aveRange, &stdDevRange);
 
   frsmPoint origin = { 0, 0 };


### PR DESCRIPTION
This modification introduces the possibility to choose a minimum range for the LiDAR. This is useful if there is self cluttering (e.g. cables in front of the sensors) and you want to filter this out.

**WARNING:**  most of the arguments of `frsm_projectRangesToPoint()` are optional and `double`. 
When calling the function you have to specify a minValue if you want to set the arguments after `minRange`. If you don't do that, the old signature will use the next argument for `minRange`, i.e., also [here](https://github.com/openhumanoids/pronto/blob/master/lidar_odometry/src/lidar_odometry/lidar-odometry.cpp#L112) the call has to be changed.
